### PR TITLE
ci: make package releases immutable-safe

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -154,6 +154,41 @@ jobs:
         with:
           subject-path: sbom.cdx.json
 
+      - name: Push release commit and tag
+        if: ${{ steps.release.outputs.should_push == 'true' }}
+        run: |
+          set -euo pipefail
+          git push
+          git push --tags
+
+      - name: Create GitHub Release draft (immutable-safe)
+        env:
+          GH_TOKEN: ${ secrets.GITHUB_TOKEN }
+          TAG: ${ steps.release.outputs.release_tag }
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            IS_DRAFT="$(gh release view "$TAG" --json isDraft --jq '.isDraft')"
+            if [ "$IS_DRAFT" != "true" ]; then
+              echo "Release $TAG already exists and is published. Immutable releases cannot be modified after publication; cut a new version instead."
+              exit 1
+            fi
+
+            echo "Draft release $TAG already exists; refreshing mutable assets."
+            if [ -s sbom.cdx.json ]; then
+              gh release upload "$TAG" sbom.cdx.json --clobber
+            else
+              echo "Skipping SBOM release upload (file missing or empty)."
+            fi
+          else
+            if [ -s sbom.cdx.json ]; then
+              gh release create "$TAG" sbom.cdx.json --title "Release $TAG" --generate-notes --verify-tag --draft
+            else
+              gh release create "$TAG" --title "Release $TAG" --generate-notes --verify-tag --draft
+            fi
+          fi
+
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -172,37 +207,21 @@ jobs:
             npm publish --provenance --registry https://registry.npmjs.org
           fi
 
-      - name: Push release commit and tag
-        if: ${{ steps.release.outputs.should_push == 'true' }}
-        run: |
-          set -euo pipefail
-          git push
-          git push --tags
-
-      - name: Create GitHub Release
+      - name: Publish GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs.release_tag }}
+          GH_TOKEN: ${ secrets.GITHUB_TOKEN }
+          TAG: ${ steps.release.outputs.release_tag }
         run: |
           set -euo pipefail
 
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists"
-          else
-            gh release create "$TAG" --title "Release $TAG" --generate-notes --latest
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Expected draft release $TAG to exist before publication."
+            exit 1
           fi
 
-          if [ "${{ steps.sbom.outputs.generated }}" = "true" ] && [ -s sbom.cdx.json ]; then
-            for attempt in 1 2 3; do
-              if gh release upload "$TAG" sbom.cdx.json --clobber; then
-                break
-              fi
-              if [ "$attempt" -eq 3 ]; then
-                echo "SBOM upload failed after retries." >&2
-                exit 1
-              fi
-              sleep $((attempt * 5))
-            done
+          IS_DRAFT="$(gh release view "$TAG" --json isDraft --jq '.isDraft')"
+          if [ "$IS_DRAFT" = "true" ]; then
+            gh release edit "$TAG" --draft=false --latest
           else
-            echo "Skipping SBOM release upload (file missing/empty or generation failed)."
+            echo "Release $TAG is already published; skipping publication."
           fi


### PR DESCRIPTION
## Summary
- create GitHub Releases as drafts before publication
- attach or refresh the SBOM only while the release is still mutable
- publish the GitHub Release only after npm publish succeeds

## Why
The immutable release policy blocks post-publication asset uploads, so the previous flow fails with HTTP 422 when it tries to upload the SBOM after publishing the release.
