### PR TITLE
ci: fix immutable-safe release expressions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -163,8 +163,8 @@ jobs:
 
       - name: Create GitHub Release draft (immutable-safe)
         env:
-          GH_TOKEN: ${ secrets.GITHUB_TOKEN }
-          TAG: ${ steps.release.outputs.release_tag }
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.release_tag }}
         run: |
           set -euo pipefail
 
@@ -209,8 +209,8 @@ jobs:
 
       - name: Publish GitHub Release
         env:
-          GH_TOKEN: ${ secrets.GITHUB_TOKEN }
-          TAG: ${ steps.release.outputs.release_tag }
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.release_tag }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- repair GitHub Actions expressions in the immutable-safe release steps
- preserve draft-first release publication for immutable releases

## Why
The first rollout templated `${{ ... }}` expressions incorrectly into `${ ... }`, which breaks shell evaluation before the release step can run.
