### PR TITLE
feat: add agentic foundation contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
+  - Added agentic foundation contracts for task kinds, request envelopes, rollout metadata, provider/model catalogs, usage metering, confidence, and cost.
+  - Added canonical `ai.agentic.foundation.enabled` rollout metadata and fail-closed helper utilities for host-controlled feature-flag evaluation.
+  - Added ADR-0006 documenting why orchestration stays in downstream `@plasius/ai-*` packages while shared contracts stay in `@plasius/ai`.
   - Added completion-schema serialization tests covering public and internal payload variants.
   - Added built-in provider adapter factories:
     - `createOpenAIAdapter` for chat, speech synthesis, transcription, image generation, and model generation.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@
 [![Security Policy](https://img.shields.io/badge/security%20policy-yes-orange.svg)](./SECURITY.md)
 [![Changelog](https://img.shields.io/badge/changelog-md-blue.svg)](./CHANGELOG.md)
 
-AI capability contracts and completion schemas for Plasius applications.
+AI capability contracts, completion schemas, and agentic foundation contracts for Plasius applications.
 
 ## Scope
 
 This package currently provides:
 
 - capability contracts (`AICapability`, `AIPlatform`)
+- agentic foundation contracts for request envelopes, task kinds, rollout metadata, provider/model catalogs, and metering
 - completion model interfaces (`ChatCompletion`, `ImageCompletion`, `ModelCompletion`, etc.)
 - schema definitions for completion entities
 - adapter contracts/factories for multi-provider routing with developer-supplied API keys
@@ -94,6 +95,17 @@ void platform;
 
 - `AICapability`: enum describing logical capability routing.
 - `AIPlatform`: interface your runtime adapter must implement.
+- Agentic foundation contracts and helpers:
+  - `AI_FEATURE_FLAGS`
+  - `AI_AGENTIC_FOUNDATION_ROLLOUT`
+  - `createAITaskKind`
+  - `createAIRequestEnvelope`
+  - `resolveAIRolloutDecision`
+  - `AIProviderDescriptor`
+  - `AIModelCatalogEntry`
+  - `AIUsageMetrics`
+  - `AICostEstimate`
+  - `AIConfidenceScore`
 - Generic multi-capability adapter contracts and helpers:
   - `AICapabilityAdapter`
   - `AdapterPlatformProps`
@@ -139,7 +151,7 @@ Completion schemas validate persisted records, including the internal `partition
 
 - `src/lib/*` currently contains placeholder files and is not part of the public API.
 - Provider-specific runtime adapters are still under stabilization and should be wrapped by host applications.
-- The package focuses on contracts/schemas first; runtime behavior is expected to be composed by consumers.
+- The package focuses on contracts/schemas first; runtime behavior is expected to be composed by consumers or downstream `@plasius/ai-*` packages.
 
 ### Multi-Capability Adapter Composition
 
@@ -229,6 +241,47 @@ const publicPayload = completionSchema.serialize(persistedCompletion);
 // partitionKey is omitted by default.
 
 void publicPayload;
+```
+
+### Agentic foundation contracts
+
+```ts
+import {
+  AI_FEATURE_FLAGS,
+  createAIRequestEnvelope,
+  createAITaskKind,
+  resolveAIRolloutDecision,
+} from "@plasius/ai";
+
+const rollout = resolveAIRolloutDecision(
+  {
+    featureFlag: AI_FEATURE_FLAGS.agenticFoundation,
+    evaluator: "remote-flag-service",
+    defaultEnabled: false,
+    fallbackMode: "fail-closed",
+  },
+  {
+    [AI_FEATURE_FLAGS.agenticFoundation]: true,
+  }
+);
+
+const envelope = createAIRequestEnvelope({
+  requestId: "req-1",
+  taskKind: createAITaskKind({
+    domain: "routing",
+    action: "select",
+  }),
+  actor: {
+    actorId: "user-1",
+    actorType: "user",
+  },
+  input: {
+    prompt: "Choose the cheapest safe model.",
+  },
+});
+
+void rollout;
+void envelope;
 ```
 
 ### Generic Video Adapter Composition

--- a/docs/adrs/adr-0006-agentic-foundation-contracts-and-package-family-split.md
+++ b/docs/adrs/adr-0006-agentic-foundation-contracts-and-package-family-split.md
@@ -1,0 +1,29 @@
+# ADR-0006: Keep Agentic Foundation Contracts in @plasius/ai and Move Orchestration Downstream
+
+- Date: 2026-05-13
+- Status: Accepted
+
+## Context
+
+The Plasius agentic AI package family now spans provider configuration, routing, speech, governance, MCP, RAG, game workloads, and evaluation packages. Those packages need a shared contract vocabulary for task kinds, request envelopes, provider/model catalogs, usage metering, confidence, and cost without turning `@plasius/ai` into the runtime orchestrator for every AI concern.
+
+The parent feature is controlled by `ai.agentic.foundation.enabled`, but feature-flag evaluation belongs to host control planes rather than to this public contract package. The foundation package still needs to publish the canonical flag key and a fail-closed fallback shape so downstream packages can document and test the same rollout contract consistently.
+
+## Decision
+
+Keep `@plasius/ai` as the contracts-first foundation package and add only additive agentic primitives:
+
+- canonical task-kind formatting and validation helpers;
+- generic request-envelope, rollout-control, and actor/policy contracts;
+- provider and model catalog descriptor contracts;
+- usage, pricing, cost, confidence, and execution-metrics contracts;
+- the canonical `ai.agentic.foundation.enabled` rollout descriptor with fail-closed default behavior.
+
+Do not move provider orchestration, routing policies, moderation logic, MCP policy, RAG packing, or gameplay-specific behavior into `@plasius/ai`. Those concerns belong in downstream `@plasius/ai-*` packages that import the shared foundation contracts.
+
+## Consequences
+
+- Existing `AICapability` and `AIPlatform` exports remain source-compatible for current consumers.
+- Downstream packages gain a stable public vocabulary without depending on provisional runtime glue.
+- Feature-flag evaluation remains remote and host-owned; this package only defines the canonical key and fallback shape.
+- Future package work can add package-specific task kinds and policies without reopening the `@plasius/ai` runtime boundary.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -5,3 +5,4 @@
 - [ADR-0003: Contracts-First Documentation Baseline](./adr-0003-contracts-first-documentation.md)
 - [ADR-0004: Dual ESM and CJS Runtime Compatibility](./adr-0004-dual-esm-cjs-runtime-compatibility.md)
 - [ADR-0005: Internal Completion Field Exposure](./adr-0005-internal-completion-field-exposure.md)
+- [ADR-0006: Keep Agentic Foundation Contracts in @plasius/ai and Move Orchestration Downstream](./adr-0006-agentic-foundation-contracts-and-package-family-split.md)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -33,6 +33,22 @@ Optional:
 
 - `canHandle(userId, capabilities)`
 
+### `AIRequestEnvelope<TInput, TContext, TMetadata>`
+
+Canonical request shape for downstream agentic workflows:
+
+- `requestId`
+- `createdAt`
+- `taskKind`
+- `actor`
+- `input`
+- `context?`
+- `metadata?`
+- `rollout`
+- `policy`
+
+Create envelopes with `createAIRequestEnvelope(...)` to get fail-closed rollout defaults and validated task-kind formatting.
+
 ## Completion Models
 
 Base type:
@@ -55,6 +71,40 @@ Specialized variants:
 - `VideoCompletion`
 - `ModelCompletion`
 - `BalanceCompletion`
+
+## Agentic Foundation Contracts
+
+### Feature flags and rollout
+
+- `AI_FEATURE_FLAGS`
+- `AI_AGENTIC_FOUNDATION_ROLLOUT`
+- `resolveAIRolloutDecision(control, snapshot?)`
+- `isAgenticFoundationEnabled(snapshot?)`
+
+Rollout descriptors are public contracts only. Host applications remain the source of truth for remote flag evaluation.
+
+### Task-kind helpers
+
+- `AITaskKind`
+- `AITaskKindParts`
+- `createAITaskKind(parts)`
+- `isAITaskKind(value)`
+
+Task kinds use dot-delimited lowercase segments such as `routing.select` or `game.npc-dialogue.near-cache`.
+
+### Policy, catalog, and metering types
+
+- `AIRequestActor`
+- `AIRequestPolicy`
+- `AIExecutionBudget`
+- `AIProviderDescriptor`
+- `AIModelCatalogEntry`
+- `AIUsageMetrics`
+- `AIPricingRate`
+- `AICostEstimate`
+- `AICostLineItem`
+- `AIConfidenceScore`
+- `AIExecutionMetrics`
 
 ## Adapter Composition
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,7 @@
 - **Capability model**: `AICapability` describes the logical feature set.
 - **Platform contract**: `AIPlatform` defines the async operations required by a runtime adapter.
 - **Completion contracts**: typed completion outputs normalize chat/text/image/speech/video/model/balance results.
+- **Agentic foundation contracts**: task-kind, request-envelope, rollout, provider/model catalog, usage, cost, and confidence contracts define the shared vocabulary for downstream `@plasius/ai-*` packages.
 - **Schema layer**: schema definitions ensure consistent metadata and persistence shape across runtimes.
 - **Adapter composition**: `createAdapterPlatform` routes capabilities across multiple adapters and injects API keys supplied by the package consumer.
 - **Built-in providers**: OpenAI, Gemini, Grok, Meta AI, and Pixelverse adapters are included for out-of-the-box capability wiring.
@@ -18,8 +19,15 @@ This package is not tied to a single provider runtime. Host applications should:
 2. Keep provider credentials and network execution outside this package boundary.
 3. Emit normalized completion objects based on the exported contract types.
 4. Register per-provider API keys through `AdapterPlatformProps.apiKeys`.
+5. Evaluate feature flags in the host control plane and pass canonical rollout keys through the exported request-envelope contracts.
 
 ## Current Boundaries
 
-- Public API: contracts and schemas from `src/platform/index.ts`.
-- Internal/provisional: files under `src/lib` and in-progress provider runtime glue.
+- Stable public API:
+  - completion contracts and schemas from `src/platform/index.ts`
+  - multi-provider adapter contracts
+  - agentic foundation contracts from `src/agentic-foundation.ts`
+- Internal/provisional:
+  - files under `src/lib`
+  - built-in provider runtime glue
+  - package-specific orchestration that belongs in downstream `@plasius/ai-*` packages

--- a/src/agentic-foundation.ts
+++ b/src/agentic-foundation.ts
@@ -1,0 +1,362 @@
+import type { AICapability } from "./platform/index.js";
+
+const TASK_KIND_SEGMENT_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const TASK_KIND_PATTERN =
+  /^[a-z0-9]+(?:-[a-z0-9]+)*(?:\.[a-z0-9]+(?:-[a-z0-9]+)*)+$/;
+
+function normalizeTaskKindSegment(segment: string, label: string): string {
+  const trimmed = segment.trim();
+  if (!TASK_KIND_SEGMENT_PATTERN.test(trimmed)) {
+    throw new Error(
+      `${label} must use lowercase letters, numbers, and single hyphen separators.`
+    );
+  }
+
+  return trimmed;
+}
+
+function requireNonEmptyString(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+
+  return trimmed;
+}
+
+export const AI_FEATURE_FLAGS = {
+  agenticFoundation: "ai.agentic.foundation.enabled",
+} as const;
+
+export type AIFeatureFlagKey =
+  (typeof AI_FEATURE_FLAGS)[keyof typeof AI_FEATURE_FLAGS];
+
+export type AIFeatureFlagSnapshot = Readonly<
+  Record<string, boolean | undefined>
+>;
+
+export const AI_ROLLOUT_EVALUATORS = [
+  "remote-flag-service",
+  "host-application",
+  "break-glass-env",
+] as const;
+
+export type AIRolloutEvaluator = (typeof AI_ROLLOUT_EVALUATORS)[number];
+
+export const AI_ROLLOUT_FALLBACK_MODES = ["fail-closed", "fail-open"] as const;
+
+export type AIRolloutFallbackMode =
+  (typeof AI_ROLLOUT_FALLBACK_MODES)[number];
+
+export interface AIRolloutControl {
+  featureFlag: string;
+  evaluator: AIRolloutEvaluator;
+  defaultEnabled: boolean;
+  fallbackMode: AIRolloutFallbackMode;
+}
+
+export interface AIRolloutDecision extends AIRolloutControl {
+  enabled: boolean;
+  source: "snapshot" | "default";
+}
+
+export const AI_AGENTIC_FOUNDATION_ROLLOUT: AIRolloutControl = Object.freeze({
+  featureFlag: AI_FEATURE_FLAGS.agenticFoundation,
+  evaluator: "remote-flag-service",
+  defaultEnabled: false,
+  fallbackMode: "fail-closed",
+});
+
+export function resolveAIRolloutDecision(
+  control: AIRolloutControl,
+  snapshot: AIFeatureFlagSnapshot = {}
+): AIRolloutDecision {
+  const resolved = snapshot[control.featureFlag];
+  if (typeof resolved === "boolean") {
+    return {
+      ...control,
+      enabled: resolved,
+      source: "snapshot",
+    };
+  }
+
+  return {
+    ...control,
+    enabled: control.defaultEnabled,
+    source: "default",
+  };
+}
+
+export function isAgenticFoundationEnabled(
+  snapshot: AIFeatureFlagSnapshot = {}
+): boolean {
+  return resolveAIRolloutDecision(
+    AI_AGENTIC_FOUNDATION_ROLLOUT,
+    snapshot
+  ).enabled;
+}
+
+export interface AITaskKindParts {
+  domain: string;
+  action: string;
+  variant?: string;
+}
+
+export type AITaskKind = `${string}.${string}`;
+
+export function isAITaskKind(value: string): value is AITaskKind {
+  return TASK_KIND_PATTERN.test(value.trim());
+}
+
+export function createAITaskKind(parts: AITaskKindParts): AITaskKind {
+  const segments = [
+    normalizeTaskKindSegment(parts.domain, "Task kind domain"),
+    normalizeTaskKindSegment(parts.action, "Task kind action"),
+  ];
+
+  if (parts.variant) {
+    segments.push(normalizeTaskKindSegment(parts.variant, "Task kind variant"));
+  }
+
+  return segments.join(".") as AITaskKind;
+}
+
+export const AI_ACTOR_TYPES = [
+  "user",
+  "service",
+  "system",
+  "moderator",
+] as const;
+
+export type AIActorType = (typeof AI_ACTOR_TYPES)[number];
+
+export const AI_RISK_TIERS = ["low", "medium", "high", "critical"] as const;
+
+export type AIRiskTier = (typeof AI_RISK_TIERS)[number];
+
+export const AI_DATA_CLASSIFICATIONS = [
+  "public",
+  "internal",
+  "personal",
+  "sensitive",
+] as const;
+
+export type AIDataClassification =
+  (typeof AI_DATA_CLASSIFICATIONS)[number];
+
+export const AI_PROVIDER_STAGES = [
+  "development",
+  "preview",
+  "stable",
+  "deprecated",
+] as const;
+
+export type AIProviderStage = (typeof AI_PROVIDER_STAGES)[number];
+
+export const AI_LATENCY_TIERS = ["fast", "balanced", "slow"] as const;
+
+export type AILatencyTier = (typeof AI_LATENCY_TIERS)[number];
+
+export const AI_CACHE_REUSE_POLICIES = [
+  "none",
+  "exact",
+  "near-text",
+] as const;
+
+export type AICacheReusePolicy =
+  (typeof AI_CACHE_REUSE_POLICIES)[number];
+
+export const AI_COST_UNITS = [
+  "1k-tokens",
+  "characters",
+  "seconds",
+  "images",
+  "requests",
+] as const;
+
+export type AICostUnit = (typeof AI_COST_UNITS)[number];
+
+export const AI_COST_CATEGORIES = [
+  "input",
+  "output",
+  "cache",
+  "request",
+  "storage",
+] as const;
+
+export type AICostCategory = (typeof AI_COST_CATEGORIES)[number];
+
+export const AI_CONFIDENCE_BANDS = ["low", "medium", "high"] as const;
+
+export type AIConfidenceBand = (typeof AI_CONFIDENCE_BANDS)[number];
+
+export interface AIRequestActor {
+  actorId: string;
+  actorType: AIActorType;
+  sessionId?: string;
+}
+
+export interface AIExecutionBudget {
+  maxLatencyMs?: number;
+  maxCostUsd?: number;
+  minimumConfidence?: number;
+}
+
+export interface AIRequestPolicy {
+  riskTier: AIRiskTier;
+  dataClassification: AIDataClassification;
+  budget?: AIExecutionBudget;
+  allowProviderIds?: readonly string[];
+  denyProviderIds?: readonly string[];
+}
+
+export interface AIRequestEnvelope<
+  TInput = unknown,
+  TContext = unknown,
+  TMetadata extends Record<string, unknown> = Record<string, unknown>,
+> {
+  requestId: string;
+  createdAt: string;
+  taskKind: AITaskKind;
+  actor: AIRequestActor;
+  input: TInput;
+  context?: TContext;
+  metadata?: TMetadata;
+  rollout: AIRolloutControl;
+  policy: AIRequestPolicy;
+}
+
+export interface CreateAIRequestEnvelopeInput<
+  TInput = unknown,
+  TContext = unknown,
+  TMetadata extends Record<string, unknown> = Record<string, unknown>,
+> {
+  requestId: string;
+  createdAt?: string;
+  taskKind: AITaskKind | AITaskKindParts;
+  actor: AIRequestActor;
+  input: TInput;
+  context?: TContext;
+  metadata?: TMetadata;
+  rollout?: AIRolloutControl;
+  policy?: Partial<AIRequestPolicy>;
+}
+
+export function createAIRequestEnvelope<
+  TInput = unknown,
+  TContext = unknown,
+  TMetadata extends Record<string, unknown> = Record<string, unknown>,
+>(
+  input: CreateAIRequestEnvelopeInput<TInput, TContext, TMetadata>
+): AIRequestEnvelope<TInput, TContext, TMetadata> {
+  const requestId = requireNonEmptyString(input.requestId, "Request id");
+  const actorId = requireNonEmptyString(input.actor.actorId, "Actor id");
+  const taskKind =
+    typeof input.taskKind === "string"
+      ? input.taskKind
+      : createAITaskKind(input.taskKind);
+
+  if (!isAITaskKind(taskKind)) {
+    throw new Error(
+      "Task kind must use dot-delimited lowercase segments such as 'routing.select'."
+    );
+  }
+
+  return {
+    requestId,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    taskKind,
+    actor: {
+      ...input.actor,
+      actorId,
+    },
+    input: input.input,
+    context: input.context,
+    metadata: input.metadata,
+    rollout: input.rollout ?? AI_AGENTIC_FOUNDATION_ROLLOUT,
+    policy: {
+      riskTier: input.policy?.riskTier ?? "low",
+      dataClassification: input.policy?.dataClassification ?? "internal",
+      budget: input.policy?.budget,
+      allowProviderIds: input.policy?.allowProviderIds,
+      denyProviderIds: input.policy?.denyProviderIds,
+    },
+  };
+}
+
+export interface AIUsageMetrics {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  characters?: number;
+  audioSeconds?: number;
+  images?: number;
+  cacheReadUnits?: number;
+  cacheWriteUnits?: number;
+  vendor?: Record<string, number>;
+}
+
+export interface AIPricingRate {
+  category: AICostCategory;
+  unit: AICostUnit;
+  unitAmount: number;
+  currency: string;
+}
+
+export interface AICostLineItem extends AIPricingRate {
+  units: number;
+  totalAmount: number;
+  description?: string;
+}
+
+export interface AICostEstimate {
+  currency: string;
+  estimatedAmount: number;
+  billedAmount?: number;
+  pricingVersion?: string;
+  lineItems?: readonly AICostLineItem[];
+}
+
+export interface AIConfidenceScore {
+  score: number;
+  scale: "0-1" | "0-100";
+  band?: AIConfidenceBand;
+  reasonCodes?: readonly string[];
+}
+
+export interface AIExecutionMetrics {
+  durationMs?: number;
+  usage?: AIUsageMetrics;
+  cost?: AICostEstimate;
+  confidence?: AIConfidenceScore;
+}
+
+export interface AIProviderDescriptor {
+  id: string;
+  displayName: string;
+  stage: AIProviderStage;
+  capabilities: readonly AICapability[];
+  supportedTaskKinds?: readonly AITaskKind[];
+  supportsPersonalData: boolean;
+  cacheReuse: AICacheReusePolicy;
+  dataResidency?: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+export interface AIModelCatalogEntry {
+  providerId: string;
+  modelId: string;
+  displayName: string;
+  stage: AIProviderStage;
+  taskKinds: readonly AITaskKind[];
+  capabilities?: readonly AICapability[];
+  latencyTier?: AILatencyTier;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+  pricing?: readonly AIPricingRate[];
+  defaultConfidence?: AIConfidenceScore;
+  cacheReuse?: AICacheReusePolicy;
+  supportsBatch?: boolean;
+  supportsStreaming?: boolean;
+  supportsPersonalData?: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./agentic-foundation.js";
 export * from "./platform/index.js";
 export * from "./lib/chatWithAI.js";

--- a/tests/agentic-foundation.tests.ts
+++ b/tests/agentic-foundation.tests.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AI_AGENTIC_FOUNDATION_ROLLOUT,
+  AI_FEATURE_FLAGS,
+  createAIRequestEnvelope,
+  createAITaskKind,
+  isAITaskKind,
+  isAgenticFoundationEnabled,
+  resolveAIRolloutDecision,
+} from "../src/index.js";
+
+describe("agentic foundation contracts", () => {
+  it("exports the canonical foundation feature flag key", () => {
+    expect(AI_FEATURE_FLAGS.agenticFoundation).toBe(
+      "ai.agentic.foundation.enabled"
+    );
+  });
+
+  it("creates dot-delimited task kinds", () => {
+    expect(
+      createAITaskKind({
+        domain: "game",
+        action: "npc-dialogue",
+        variant: "near-cache",
+      })
+    ).toBe("game.npc-dialogue.near-cache");
+  });
+
+  it("rejects invalid task kind segments", () => {
+    expect(() =>
+      createAITaskKind({
+        domain: "game",
+        action: "NPC Dialogue",
+      })
+    ).toThrow(/Task kind action/);
+  });
+
+  it("recognizes valid task kinds", () => {
+    expect(isAITaskKind("routing.select")).toBe(true);
+    expect(isAITaskKind("routing select")).toBe(false);
+  });
+
+  it("resolves rollout state from a remote snapshot", () => {
+    expect(
+      resolveAIRolloutDecision(AI_AGENTIC_FOUNDATION_ROLLOUT, {
+        [AI_FEATURE_FLAGS.agenticFoundation]: true,
+      })
+    ).toMatchObject({
+      enabled: true,
+      source: "snapshot",
+    });
+  });
+
+  it("fails closed when the foundation flag is missing", () => {
+    expect(
+      resolveAIRolloutDecision(AI_AGENTIC_FOUNDATION_ROLLOUT, {})
+    ).toMatchObject({
+      enabled: false,
+      source: "default",
+    });
+    expect(isAgenticFoundationEnabled({})).toBe(false);
+  });
+
+  it("creates request envelopes with safe defaults", () => {
+    expect(
+      createAIRequestEnvelope({
+        requestId: "req-1",
+        createdAt: "2026-05-13T09:30:00.000Z",
+        taskKind: {
+          domain: "routing",
+          action: "select",
+        },
+        actor: {
+          actorId: "user-1",
+          actorType: "user",
+        },
+        input: {
+          prompt: "Choose the cheapest safe model.",
+        },
+      })
+    ).toEqual({
+      requestId: "req-1",
+      createdAt: "2026-05-13T09:30:00.000Z",
+      taskKind: "routing.select",
+      actor: {
+        actorId: "user-1",
+        actorType: "user",
+      },
+      input: {
+        prompt: "Choose the cheapest safe model.",
+      },
+      context: undefined,
+      metadata: undefined,
+      rollout: AI_AGENTIC_FOUNDATION_ROLLOUT,
+      policy: {
+        riskTier: "low",
+        dataClassification: "internal",
+        budget: undefined,
+        allowProviderIds: undefined,
+        denyProviderIds: undefined,
+      },
+    });
+  });
+
+  it("rejects envelopes with blank actor ids", () => {
+    expect(() =>
+      createAIRequestEnvelope({
+        requestId: "req-2",
+        taskKind: "routing.select",
+        actor: {
+          actorId: "   ",
+          actorType: "service",
+        },
+        input: {},
+      })
+    ).toThrow(/Actor id/);
+  });
+});


### PR DESCRIPTION
## Summary
- add additive agentic foundation contracts to @plasius/ai
- export rollout, task-kind, request-envelope, provider/model catalog, usage, cost, and confidence primitives
- document the package-family split with ADR-0006 and update public docs/tests

## Validation
- npm run lint
- npm run typecheck
- npm test
- npm run test:coverage
- npm run pack:check

## Linked work
- Plasius-LTD/plasius-ltd-site#261
- Plasius-LTD/plasius-ltd-site#268
- Plasius-LTD/ai#2