### PR TITLE
fix: narrow createVideoProviderPlatform to supported capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - Standardized npm publish path on workflow-dispatched `.github/workflows/cd.yml` using provenance and production environment secrets.
   - Replaced `audit:deps` from `depcheck` to `npm ls --all --omit=optional --omit=peer > /dev/null 2>&1 || true` to avoid deprecated dependency-chain risk.
   - Refactored video editor/balance components to rely on injected provider adapters instead of hardcoded vendor wiring.
+  - Narrowed `createVideoProviderPlatform` to return a dedicated `VideoProviderPlatform` contract that only includes supported capabilities.
   - Removed provider-specific identifiers from code roots to enforce public package boundaries.
   - Restored CI line-coverage enforcement to `>= 80%` and Vitest thresholds to `lines/functions/statements >= 80%`, `branches >= 70%`.
   - CD install step now runs without `--legacy-peer-deps`.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ void platform;
   - `VideoProviderAdapter`
   - `VideoGenerationRequest`
   - `createHttpVideoProviderAdapter`
+  - `VideoProviderPlatform`
   - `createVideoProviderPlatform`
+    - Contract key: `platform.repo-hardening-sweep.enabled`
 - `Completion` + typed completion variants:
   - `ChatCompletion`
   - `TextCompletion`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -33,6 +33,14 @@ Optional:
 
 - `canHandle(userId, capabilities)`
 
+### `VideoProviderPlatform`
+
+Video-only platform contract used by `createVideoProviderPlatform`:
+
+- `produceVideo(userId, input, image, context, model)`
+- `checkBalance(userId)`
+- `currentBalance`
+
 ### `AIRequestEnvelope<TInput, TContext, TMetadata>`
 
 Canonical request shape for downstream agentic workflows:
@@ -78,6 +86,7 @@ Specialized variants:
 
 - `AI_FEATURE_FLAGS`
 - `AI_AGENTIC_FOUNDATION_ROLLOUT`
+- `VIDEO_PROVIDER_PLATFORM_HARDENING_FEATURE_FLAG`
 - `resolveAIRolloutDecision(control, snapshot?)`
 - `isAgenticFoundationEnabled(snapshot?)`
 
@@ -182,6 +191,10 @@ Creates a Pixelverse adapter implementing:
 
 - `produceVideo`
 - `checkBalance`
+
+### `createVideoProviderPlatform`
+
+Builds a `VideoProviderPlatform` from a `VideoProviderAdapter`.
 
 ## Exported Schemas
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,17 +66,6 @@
         "node": ">=6.9.0"
       }
     },
-<<<<<<< HEAD
-    "node_modules/@babel/code-frame/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-=======
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -852,21 +841,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "0.129.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
       "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
-=======
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -874,15 +851,9 @@
       }
     },
     "node_modules/@plasius/analytics": {
-<<<<<<< HEAD
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@plasius/analytics/-/analytics-1.1.11.tgz",
       "integrity": "sha512-FheQkkbDgpi5asdJ4Eg40r7xe3rEooZpmsVob4W5dynJRgRZNum+xwD61lBPrZN6M6Tl7gjh2Ih7RCMp20FlOA==",
-=======
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@plasius/analytics/-/analytics-1.1.9.tgz",
-      "integrity": "sha512-702bkuaJLTZYhZOumWnbHcNdun/oKg+VkKOdg/OI9sc7RjebAsucfBMCLaPfwOfC2sRK/AVjSBmn3pcdWqMETg==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       "funding": [
         {
           "type": "patreon",
@@ -895,11 +866,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-<<<<<<< HEAD
         "@plasius/schema": "^1.2.11"
-=======
-        "@plasius/schema": "^1.2.10"
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       },
       "engines": {
         "node": ">=24"
@@ -934,9 +901,9 @@
       }
     },
     "node_modules/@plasius/entity-manager": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@plasius/entity-manager/-/entity-manager-1.0.16.tgz",
-      "integrity": "sha512-V2vv8CCP8+8yDAxYihMElFxVZoUg/OIabq5Sn3nk5NpA+GEmZ/RBmeyK+J9EffFeHj5X0ts8qZMxVx9SQ0v76A==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@plasius/entity-manager/-/entity-manager-1.0.17.tgz",
+      "integrity": "sha512-fHNw3Gpf4R3p3Ms67c6c0p8uAbVFH6voo8E3i5BBLZcLqFr7YFezjeyUVMwYbeRm58JiLP6U9FNpwxE+64bWfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@plasius/schema": "^1.2.11"
@@ -946,15 +913,9 @@
       }
     },
     "node_modules/@plasius/environment": {
-<<<<<<< HEAD
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@plasius/environment/-/environment-1.0.15.tgz",
       "integrity": "sha512-+osPPuZ4HWtvjeAHwVP5Sue18+g7vjXdA9rD8krfIr3As9/D66bRfvtWq7EhaadwEItezrPXts8aP7fvF0YKIw==",
-=======
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@plasius/environment/-/environment-1.0.14.tgz",
-      "integrity": "sha512-rPpqFk9Wo1yQZMQudiK7MiF1mrCFkskJNFqKBSUuu76C/cLQF/4UfrIg+uwStuhyyzQVMSBiKcYnlYE7fRjXcA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       "funding": [
         {
           "type": "patreon",
@@ -974,15 +935,9 @@
       }
     },
     "node_modules/@plasius/error": {
-<<<<<<< HEAD
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@plasius/error/-/error-1.0.15.tgz",
       "integrity": "sha512-/mnsgdVeggpTUzaYvL5pNVPLoOIoGD6q7kBArddEIt/BS7UQbqoae2jHaqU5PB0lOPjwKDWtugxdR/6uaAv5HQ==",
-=======
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@plasius/error/-/error-1.0.13.tgz",
-      "integrity": "sha512-Fzz8f/SAZinuXOtj0mmPmBR2t6fQMuY9PtlItv8lcPHB8jinvffF4oioSKxlyuIi7aNte+Tdm+UIuS+tIN6zfQ==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       "funding": [
         {
           "type": "patreon",
@@ -1003,15 +958,9 @@
       }
     },
     "node_modules/@plasius/nfr": {
-<<<<<<< HEAD
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@plasius/nfr/-/nfr-1.0.8.tgz",
       "integrity": "sha512-6Yz7ARJyZfZCWu/kiWmyZyTHYuVqGVB2nFPAnG9a/W8Q8I/5ueV43/yQJI2c7Ckz9SmAb23YkBYJLilofGTLgA==",
-=======
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@plasius/nfr/-/nfr-1.0.7.tgz",
-      "integrity": "sha512-ZBDhcaJJBM8O5QoFhLC2nNkhQlqZIPUzVyn4EP7G+AUOD1prHCr1mR/QSymiVFRwaxyET5UWCfnZTKJ8zeJL4w==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       "funding": [
         {
           "type": "patreon",
@@ -1095,15 +1044,9 @@
       }
     },
     "node_modules/@plasius/react-state": {
-<<<<<<< HEAD
       "version": "1.2.12",
       "resolved": "https://registry.npmjs.org/@plasius/react-state/-/react-state-1.2.12.tgz",
       "integrity": "sha512-kfbQj4CcUidpKw2rMEF+5r4RQqauhvzLme01Ex8o02M836yHX7wcfRLqOVKm0BeSrttZNX3PYcCdArZ0HnQtuA==",
-=======
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@plasius/react-state/-/react-state-1.2.10.tgz",
-      "integrity": "sha512-xipCJcf9hU9ZmqhbDmkzRa6Wt5Ley+4B42jBYzHFutzqBbdshTR31mlPv0KIJpqF+4mMhQmyDYzs7k6w6FaqFw==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       "funding": [
         {
           "type": "patreon",
@@ -1116,11 +1059,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-<<<<<<< HEAD
         "@plasius/nfr": "^1.0.8"
-=======
-        "@plasius/nfr": "^1.0.7"
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       },
       "engines": {
         "node": ">=24"
@@ -1130,15 +1069,9 @@
       }
     },
     "node_modules/@plasius/schema": {
-<<<<<<< HEAD
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@plasius/schema/-/schema-1.2.11.tgz",
       "integrity": "sha512-HQOq2Nbj9lKuY2DJC7WzRnvd5nfKc3AKlQfG8fW40VJN4/UPVE4rUdLqgsqZSBWnA1FFKIQCEk69Q0cevgFrrQ==",
-=======
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@plasius/schema/-/schema-1.2.10.tgz",
-      "integrity": "sha512-8FXycXUPcbNzxTrVpGNzq1MfTks7Q/SDNF74Bi6Id0cfhv3x0z1J+5kEZp1CKr2lyDYxLMa4zHIn+X/8zajQwA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       "funding": [
         {
           "type": "patreon",
@@ -1180,15 +1113,9 @@
       }
     },
     "node_modules/@plasius/translations": {
-<<<<<<< HEAD
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/@plasius/translations/-/translations-1.0.17.tgz",
       "integrity": "sha512-T3BDuaCHg/W5Z0Ps8+MvEkZRC92HLA1jGHkH5CZKRIEbTZdaunstg0xMCNvyb/78C6sZ79+BNPiweK0uTZ1W3g==",
-=======
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@plasius/translations/-/translations-1.0.16.tgz",
-      "integrity": "sha512-bgVMnVvNGPxETfa3zxzU8rGYtVi3IPbNoGRuVcIn9JA+Ww4RXYPOD1c7TA/EPoasjUnymms7x71JYEb0nVJPsg==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
       "funding": [
         {
           "type": "patreon",
@@ -1208,21 +1135,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
       "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "arm64"
       ],
@@ -1237,21 +1152,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
       "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "arm64"
       ],
@@ -1266,21 +1169,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
       "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "x64"
       ],
@@ -1295,21 +1186,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
       "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "x64"
       ],
@@ -1324,21 +1203,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
       "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
-      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "arm"
       ],
@@ -1353,21 +1220,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
       "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "arm64"
       ],
@@ -1382,21 +1237,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
       "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "arm64"
       ],
@@ -1411,21 +1254,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
       "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "ppc64"
       ],
@@ -1440,21 +1271,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
       "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "s390x"
       ],
@@ -1469,21 +1288,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
       "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "x64"
       ],
@@ -1498,21 +1305,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
       "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "x64"
       ],
@@ -1527,21 +1322,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
       "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "arm64"
       ],
@@ -1556,21 +1339,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
       "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
-      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "wasm32"
       ],
@@ -1587,21 +1358,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
       "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "arm64"
       ],
@@ -1616,21 +1375,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
       "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "cpu": [
         "x64"
       ],
@@ -1645,21 +1392,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
       "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
-      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "license": "MIT"
     },
@@ -1778,15 +1513,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-<<<<<<< HEAD
       "version": "25.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
       "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
-=======
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1804,43 +1533,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
       "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-<<<<<<< HEAD
-<<<<<<< HEAD
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/type-utils": "8.59.3",
         "@typescript-eslint/utils": "8.59.3",
         "@typescript-eslint/visitor-keys": "8.59.3",
-=======
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1853,22 +1556,12 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-<<<<<<< HEAD
-<<<<<<< HEAD
         "@typescript-eslint/parser": "^8.59.3",
-=======
-        "@typescript-eslint/parser": "^8.59.1",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-        "@typescript-eslint/parser": "^8.59.2",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
@@ -1879,30 +1572,6 @@
         "@typescript-eslint/types": "8.59.3",
         "@typescript-eslint/typescript-estree": "8.59.3",
         "@typescript-eslint/visitor-keys": "8.59.3",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1918,8 +1587,6 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
       "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
@@ -1928,26 +1595,6 @@
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.59.3",
         "@typescript-eslint/types": "^8.59.3",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1962,8 +1609,6 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
       "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
@@ -1972,26 +1617,6 @@
       "dependencies": {
         "@typescript-eslint/types": "8.59.3",
         "@typescript-eslint/visitor-keys": "8.59.3"
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2002,21 +1627,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
       "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2031,8 +1644,6 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
       "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
@@ -2042,28 +1653,6 @@
         "@typescript-eslint/types": "8.59.3",
         "@typescript-eslint/typescript-estree": "8.59.3",
         "@typescript-eslint/utils": "8.59.3",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2080,21 +1669,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
       "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2106,8 +1683,6 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
       "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
@@ -2118,30 +1693,6 @@
         "@typescript-eslint/tsconfig-utils": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
         "@typescript-eslint/visitor-keys": "8.59.3",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2160,40 +1711,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
       "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-<<<<<<< HEAD
-<<<<<<< HEAD
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
         "@typescript-eslint/typescript-estree": "8.59.3"
-=======
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2208,8 +1735,6 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
       "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
@@ -2217,24 +1742,6 @@
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.59.3",
-=======
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5104,21 +4611,9 @@
       }
     },
     "node_modules/postcss": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-=======
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "funding": [
         {
@@ -5195,42 +4690,18 @@
       }
     },
     "node_modules/react": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
-=======
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
-=======
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -5248,21 +4719,9 @@
       "peer": true
     },
     "node_modules/react-router": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
       "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
-=======
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
-      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5282,30 +4741,12 @@
       }
     },
     "node_modules/react-router-dom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
       "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
       "license": "MIT",
       "dependencies": {
         "react-router": "7.15.0"
-=======
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.14.2"
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.15.0"
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5417,8 +4858,6 @@
       }
     },
     "node_modules/rolldown": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
       "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
@@ -5427,26 +4866,6 @@
       "dependencies": {
         "@oxc-project/types": "=0.129.0",
         "@rolldown/pluginutils": "1.0.0"
-=======
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
-      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.128.0",
-        "@rolldown/pluginutils": "1.0.0-rc.18"
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5455,8 +4874,6 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-<<<<<<< HEAD
-<<<<<<< HEAD
         "@rolldown/binding-android-arm64": "1.0.0",
         "@rolldown/binding-darwin-arm64": "1.0.0",
         "@rolldown/binding-darwin-x64": "1.0.0",
@@ -5472,40 +4889,6 @@
         "@rolldown/binding-wasm32-wasi": "1.0.0",
         "@rolldown/binding-win32-arm64-msvc": "1.0.0",
         "@rolldown/binding-win32-x64-msvc": "1.0.0"
-=======
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       }
     },
     "node_modules/safe-array-concat": {
@@ -6182,38 +5565,16 @@
       }
     },
     "node_modules/vite": {
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "8.0.12",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
-=======
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
-      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-<<<<<<< HEAD
-<<<<<<< HEAD
         "postcss": "^8.5.14",
         "rolldown": "1.0.0",
-=======
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
->>>>>>> 9e5148a (chore: npm update (2026-05-03))
-=======
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.0-rc.18",
->>>>>>> 8923e03 (chore: npm update (2026-05-10))
         "tinyglobby": "^0.2.16"
       },
       "bin": {

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -299,6 +299,8 @@ export type {
 } from "./adapter-platform.js";
 export { createAdapterPlatform } from "./adapter-platform.js";
 export type { VideoProviderPlatformProps } from "./video-provider-platform.js";
+export type { VideoProviderPlatform } from "./video-provider-platform.js";
+export { VIDEO_PROVIDER_PLATFORM_HARDENING_FEATURE_FLAG } from "./video-provider-platform.js";
 export { createVideoProviderPlatform } from "./video-provider-platform.js";
 export type { OpenAIAdapterOptions } from "./openai-adapter.js";
 export { createOpenAIAdapter } from "./openai-adapter.js";

--- a/src/platform/video-provider-platform.ts
+++ b/src/platform/video-provider-platform.ts
@@ -1,14 +1,8 @@
 import { performance } from "node:perf_hooks";
 
 import type {
-  AIPlatform,
   BalanceCompletion,
-  ChatCompletion,
   Completion,
-  ImageCompletion,
-  ModelCompletion,
-  SpeechCompletion,
-  TextCompletion,
   VideoCompletion,
 } from "./index.js";
 import type {
@@ -26,6 +20,21 @@ export interface VideoProviderPlatformProps {
   };
   defaultVideoRequest?: Partial<Omit<VideoGenerationRequest, "imageId" | "prompt">>;
 }
+
+export interface VideoProviderPlatform {
+  produceVideo: (
+    requestorId: string,
+    prompt: string,
+    image: URL,
+    context: string,
+    model: string
+  ) => Promise<VideoCompletion>;
+  checkBalance: (userId: string) => Promise<BalanceCompletion>;
+  currentBalance: number;
+}
+
+export const VIDEO_PROVIDER_PLATFORM_HARDENING_FEATURE_FLAG =
+  "platform.repo-hardening-sweep.enabled";
 
 function createCompletionBase(
   type: string,
@@ -74,7 +83,7 @@ async function waitForCompletion(
 export async function createVideoProviderPlatform(
   userId: string,
   props: VideoProviderPlatformProps
-): Promise<AIPlatform> {
+): Promise<VideoProviderPlatform> {
   const apiKey = props.apiKey.trim();
   if (!apiKey) {
     throw new Error("apiKey is required for createVideoProviderPlatform.");
@@ -82,43 +91,6 @@ export async function createVideoProviderPlatform(
 
   const maxRetries = props.polling?.maxRetries ?? 20;
   const delayMs = props.polling?.delayMs ?? 3000;
-
-  const chatWithAI = (
-    _userId: string,
-    _input: string,
-    _context: string,
-    _model: string
-  ): Promise<ChatCompletion> => {
-    return Promise.reject(new Error("Not implemented"));
-  };
-
-  const synthesizeSpeech = (
-    _userId: string,
-    _input: string,
-    _voice: string,
-    _context: string,
-    _model: string
-  ): Promise<SpeechCompletion> => {
-    return Promise.reject(new Error("Not implemented"));
-  };
-
-  const transcribeSpeech = (
-    _userId: string,
-    _input: Buffer,
-    _context: string,
-    _model: string
-  ): Promise<TextCompletion> => {
-    return Promise.reject(new Error("Not implemented"));
-  };
-
-  const generateImage = (
-    _userId: string,
-    _input: string,
-    _context: string,
-    _model: string
-  ): Promise<ImageCompletion> => {
-    return Promise.reject(new Error("Not implemented"));
-  };
 
   const produceVideo = async (
     requestorId: string,
@@ -163,15 +135,6 @@ export async function createVideoProviderPlatform(
     };
   };
 
-  const generateModel = (
-    _userId: string,
-    _input: string,
-    _context: string,
-    _model: string
-  ): Promise<ModelCompletion> => {
-    return Promise.reject(new Error("Not implemented"));
-  };
-
   const checkBalance = async (requestorId: string): Promise<BalanceCompletion> => {
     const startedAt = performance.now();
     const providerBalance = props.adapter.getBalance
@@ -196,12 +159,7 @@ export async function createVideoProviderPlatform(
   const currentBalance = (await checkBalance(userId)).balance;
 
   return {
-    chatWithAI,
-    synthesizeSpeech,
-    transcribeSpeech,
-    generateImage,
     produceVideo,
-    generateModel,
     checkBalance,
     currentBalance,
   };

--- a/tests/video-provider-platform.tests.ts
+++ b/tests/video-provider-platform.tests.ts
@@ -117,28 +117,22 @@ describe("createVideoProviderPlatform", () => {
     expect(balance.type).toBe("balanceCompletion");
   });
 
-  it("rejects unsupported capability methods", async () => {
+  it("exposes only the video platform capability surface", async () => {
     const platform = await createVideoProviderPlatform("user-3", {
       apiKey: "video-key",
       adapter: createAdapter(),
       polling: { maxRetries: 1, delayMs: 0 },
     });
 
-    await expect(platform.chatWithAI("user-3", "hi", "", "model")).rejects.toThrow(
-      "Not implemented"
-    );
-    await expect(
-      platform.synthesizeSpeech("user-3", "hi", "voice", "", "model")
-    ).rejects.toThrow("Not implemented");
-    await expect(
-      platform.transcribeSpeech("user-3", Buffer.from("x"), "", "model")
-    ).rejects.toThrow("Not implemented");
-    await expect(platform.generateImage("user-3", "prompt", "", "model")).rejects.toThrow(
-      "Not implemented"
-    );
-    await expect(platform.generateModel("user-3", "prompt", "", "model")).rejects.toThrow(
-      "Not implemented"
-    );
+    expect(typeof platform.produceVideo).toBe("function");
+    expect(typeof platform.checkBalance).toBe("function");
+    expect(typeof platform.currentBalance).toBe("number");
+    expect("chatWithAI" in platform).toBe(false);
+    expect("synthesizeSpeech" in platform).toBe(false);
+    expect("transcribeSpeech" in platform).toBe(false);
+    expect("generateImage" in platform).toBe(false);
+    expect("generateModel" in platform).toBe(false);
+    expect("canHandle" in platform).toBe(false);
   });
 
   it("fails when provider reports failed state", async () => {


### PR DESCRIPTION
## Summary
- Fixed `createVideoProviderPlatform` to return a dedicated `VideoProviderPlatform` interface with only supported methods (`produceVideo`, `checkBalance`, `currentBalance`).
- Removed hardcoded `Not implemented` stubs from this function surface.
- Added `VIDEO_PROVIDER_PLATFORM_HARDENING_FEATURE_FLAG` export (`platform.repo-hardening-sweep.enabled`) and documented it.
- Updated API docs and changelog for contract shape.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test -- tests/video-provider-platform.tests.ts` (blocked in this environment: `node:util.styleText` import error from `rolldown`)

Closes: #8
