### PR TITLE
[codex] Localize Pixelverse display text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - Added generic video-provider adapter contracts (`VideoProviderAdapter`, request/result types).
   - Added `createHttpVideoProviderAdapter` for host-defined HTTP endpoint mapping.
   - Added `createVideoProviderPlatform` to compose `AIPlatform` video/balance behavior from adapters.
+  - Added Pixelverse `en-GB` UI translation defaults and helper exports backed by `@plasius/translations`.
 
 - **Changed**
   - Raised the minimum `@plasius/schema` dependency to `^1.2.6`.
@@ -43,6 +44,7 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - Standardized npm publish path on workflow-dispatched `.github/workflows/cd.yml` using provenance and production environment secrets.
   - Replaced `audit:deps` from `depcheck` to `npm ls --all --omit=optional --omit=peer > /dev/null 2>&1 || true` to avoid deprecated dependency-chain risk.
   - Refactored video editor/balance components to rely on injected provider adapters instead of hardcoded vendor wiring.
+  - Refactored Pixelverse editor/balance display text to resolve through package translations with a consumer-supplied `translate` override.
   - Narrowed `createVideoProviderPlatform` to return a dedicated `VideoProviderPlatform` contract that only includes supported capabilities.
   - Removed provider-specific identifiers from code roots to enforce public package boundaries.
   - Restored CI line-coverage enforcement to `>= 80%` and Vitest thresholds to `lines/functions/statements >= 80%`, `branches >= 70%`.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ void platform;
   - `VideoProviderPlatform`
   - `createVideoProviderPlatform`
     - Contract key: `platform.repo-hardening-sweep.enabled`
+- Pixelverse component translation helpers:
+  - `pixelverseEnGbTranslations`
+  - `pixelverseTranslationKeys`
+  - `translatePixelverseText`
 - `Completion` + typed completion variants:
   - `ChatCompletion`
   - `TextCompletion`
@@ -307,6 +311,26 @@ const platform = await createVideoProviderPlatform("user-1", {
 });
 
 void platform;
+```
+
+### Pixelverse UI Translations
+
+Pixelverse editor components keep their display text in the package-owned `en-GB`
+dictionary and resolve defaults through `@plasius/translations`. Host
+applications can pass a `translate` function to `VideoGenerationEditor` or
+`Balance` when they need a different locale while preserving the package
+fallbacks.
+
+```tsx
+import type { PixelverseTranslate } from "@plasius/ai";
+
+const translate: PixelverseTranslate = (key, args) => i18n.t(key, args);
+
+<VideoGenerationEditor
+  apiKey={apiKey}
+  adapter={videoAdapter}
+  translate={translate}
+/>;
 ```
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "@plasius/entity-manager": "^1.0.16",
         "@plasius/error": "^1.0.15",
         "@plasius/profile": "^1.0.33",
-        "@plasius/schema": "^1.2.11"
+        "@plasius/schema": "^1.2.11",
+        "@plasius/translations": "^1.0.17"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "@plasius/entity-manager": "^1.0.16",
     "@plasius/error": "^1.0.15",
     "@plasius/profile": "^1.0.33",
-    "@plasius/schema": "^1.2.11"
+    "@plasius/schema": "^1.2.11",
+    "@plasius/translations": "^1.0.17"
   },
   "peerDependencies": {
     "react": "^19"

--- a/src/components/pixelverse/balance.tsx
+++ b/src/components/pixelverse/balance.tsx
@@ -1,14 +1,25 @@
 import { useEffect, useState } from "react";
 import type { ProviderBalance, VideoProviderAdapter } from "../../platform/video-provider-adapter.js";
+import {
+  pixelverseTranslationKeys,
+  translatePixelverseText,
+  type PixelverseTranslate,
+} from "./i18n.js";
 import styles from "./balance.module.css";
 
 export interface BalanceProps {
   apiKey: string;
   adapter: VideoProviderAdapter;
   refreshMs?: number;
+  translate?: PixelverseTranslate;
 }
 
-export default function Balance({ apiKey, adapter, refreshMs = 600000 }: BalanceProps) {
+export default function Balance({
+  apiKey,
+  adapter,
+  refreshMs = 600000,
+  translate,
+}: BalanceProps) {
   const [balance, setBalance] = useState<ProviderBalance | null>(null);
 
   const fetchBalance = async (): Promise<void> => {
@@ -41,11 +52,29 @@ export default function Balance({ apiKey, adapter, refreshMs = 600000 }: Balance
     <div className={styles.balance_container}>
       {balance ? (
         <div>
-          <p>Monthly Credit: {balance.monthlyCredit}</p>
-          <p>Package Credit: {balance.packageCredit}</p>
+          <p>
+            {translatePixelverseText(
+              pixelverseTranslationKeys.balanceMonthlyCredit,
+              { value: balance.monthlyCredit },
+              translate
+            )}
+          </p>
+          <p>
+            {translatePixelverseText(
+              pixelverseTranslationKeys.balancePackageCredit,
+              { value: balance.packageCredit },
+              translate
+            )}
+          </p>
         </div>
       ) : (
-        <p>Loading balance...</p>
+        <p>
+          {translatePixelverseText(
+            pixelverseTranslationKeys.balanceLoading,
+            undefined,
+            translate
+          )}
+        </p>
       )}
     </div>
   );

--- a/src/components/pixelverse/i18n.ts
+++ b/src/components/pixelverse/i18n.ts
@@ -1,0 +1,49 @@
+import { createI18n } from "@plasius/translations";
+import type { TranslationArgs, TranslationDictionary } from "@plasius/translations";
+import { pixelverseEnGbTranslations } from "./translations/en-GB.js";
+
+export const pixelverseTranslationKeys = {
+  balanceLoading: "pixelverse.balance.loading",
+  balanceMonthlyCredit: "pixelverse.balance.monthlyCredit",
+  balancePackageCredit: "pixelverse.balance.packageCredit",
+  videoErrorFailed: "pixelverse.video.error.failed",
+  videoErrorTimeout: "pixelverse.video.error.timeout",
+  videoLoading: "pixelverse.video.loading",
+  videoPromptLabel: "pixelverse.video.promptLabel",
+  videoRegenerate: "pixelverse.video.regenerate",
+  videoStartUpload: "pixelverse.video.startUpload",
+  videoUploadImageTitle: "pixelverse.video.uploadImageTitle",
+  videoUploadPrompt: "pixelverse.video.uploadPrompt",
+} as const;
+
+export type PixelverseTranslationKey =
+  (typeof pixelverseTranslationKeys)[keyof typeof pixelverseTranslationKeys];
+
+export type PixelverseTranslate = (
+  key: PixelverseTranslationKey,
+  args?: TranslationArgs
+) => string | undefined;
+
+export const pixelverseTranslations = {
+  "en-GB": pixelverseEnGbTranslations,
+} satisfies Partial<Record<string, TranslationDictionary>>;
+
+const pixelverseI18n = createI18n({
+  language: "en-GB",
+  fallback: "en-GB",
+  translations: pixelverseTranslations,
+});
+
+export function translatePixelverseText(
+  key: PixelverseTranslationKey,
+  args?: TranslationArgs,
+  translate?: PixelverseTranslate
+): string {
+  const translated = translate?.(key, args);
+  if (translated && translated !== key) {
+    return translated;
+  }
+
+  return pixelverseI18n.t(key, args);
+}
+

--- a/src/components/pixelverse/index.ts
+++ b/src/components/pixelverse/index.ts
@@ -1,2 +1,4 @@
 export * from "./balance.js";
+export * from "./i18n.js";
+export * from "./translations/en-GB.js";
 export * from "./video-generation-editor.js";

--- a/src/components/pixelverse/translations/en-GB.ts
+++ b/src/components/pixelverse/translations/en-GB.ts
@@ -1,0 +1,16 @@
+import type { TranslationDictionary } from "@plasius/translations";
+
+export const pixelverseEnGbTranslations = {
+  "pixelverse.balance.loading": "Loading balance...",
+  "pixelverse.balance.monthlyCredit": "Monthly Credit: {value}",
+  "pixelverse.balance.packageCredit": "Package Credit: {value}",
+  "pixelverse.video.error.failed": "Video generation failed.",
+  "pixelverse.video.error.timeout": "Timed out waiting for video generation result.",
+  "pixelverse.video.loading": "Loading...",
+  "pixelverse.video.promptLabel": "Prompt",
+  "pixelverse.video.regenerate": "Regenerate",
+  "pixelverse.video.startUpload": "Start Upload",
+  "pixelverse.video.uploadImageTitle": "Upload Image",
+  "pixelverse.video.uploadPrompt": "Drag/Drop or Click HERE to upload",
+} satisfies TranslationDictionary;
+

--- a/src/components/pixelverse/video-generation-editor.tsx
+++ b/src/components/pixelverse/video-generation-editor.tsx
@@ -1,5 +1,10 @@
 import React, { useState } from "react";
 import Balance from "./balance.js";
+import {
+  pixelverseTranslationKeys,
+  translatePixelverseText,
+  type PixelverseTranslate,
+} from "./i18n.js";
 import type {
   VideoGenerationRequest,
   VideoProviderAdapter,
@@ -10,6 +15,7 @@ export interface VideoGenerationEditorProps {
   adapter: VideoProviderAdapter;
   onVideoGenerated?: (videoUrl: string) => void;
   initialRequest?: Partial<Omit<VideoGenerationRequest, "imageId">>;
+  translate?: PixelverseTranslate;
 }
 
 const defaultRequest: Omit<VideoGenerationRequest, "imageId"> = {
@@ -30,12 +36,13 @@ function toRequest(
   };
 }
 
-async function waitForVideoCompletion(
+export async function waitForVideoCompletion(
   adapter: VideoProviderAdapter,
   videoId: number,
   apiKey: string,
   maxRetries = 20,
-  delayMs = 3000
+  delayMs = 3000,
+  translate?: PixelverseTranslate
 ): Promise<string> {
   for (let attempt = 0; attempt < maxRetries; attempt += 1) {
     await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -49,11 +56,15 @@ async function waitForVideoCompletion(
     }
 
     if (result.state === "failed") {
-      throw new Error("Video generation failed.");
+      throw new Error(
+        translatePixelverseText(pixelverseTranslationKeys.videoErrorFailed, undefined, translate)
+      );
     }
   }
 
-  throw new Error("Timed out waiting for video generation result.");
+  throw new Error(
+    translatePixelverseText(pixelverseTranslationKeys.videoErrorTimeout, undefined, translate)
+  );
 }
 
 export function VideoGenerationEditor({
@@ -61,6 +72,7 @@ export function VideoGenerationEditor({
   adapter,
   onVideoGenerated,
   initialRequest,
+  translate,
 }: VideoGenerationEditorProps) {
   const [videoUrl, setVideoUrl] = useState("");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -104,7 +116,14 @@ export function VideoGenerationEditor({
         }
       );
 
-      const generatedUrl = await waitForVideoCompletion(adapter, generated.videoId, apiKey);
+      const generatedUrl = await waitForVideoCompletion(
+        adapter,
+        generated.videoId,
+        apiKey,
+        undefined,
+        undefined,
+        translate
+      );
       setVideoUrl(generatedUrl);
       setVideoReady(true);
       onVideoGenerated?.(generatedUrl);
@@ -115,12 +134,22 @@ export function VideoGenerationEditor({
 
   return (
     <div>
-      <Balance apiKey={apiKey} adapter={adapter} />
+      <Balance apiKey={apiKey} adapter={adapter} translate={translate} />
       {!videoReady && !selectedFile && (
         <div>
-          <p>Drag/Drop or Click HERE to upload</p>
+          <p>
+            {translatePixelverseText(
+              pixelverseTranslationKeys.videoUploadPrompt,
+              undefined,
+              translate
+            )}
+          </p>
           <input
-            title="Upload Image"
+            title={translatePixelverseText(
+              pixelverseTranslationKeys.videoUploadImageTitle,
+              undefined,
+              translate
+            )}
             type="file"
             accept=".jpg,.jpeg,.png,.webp"
             onChange={handleFileChange}
@@ -131,7 +160,11 @@ export function VideoGenerationEditor({
       {!videoReady ? (
         <div>
           <label>
-            Prompt
+            {translatePixelverseText(
+              pixelverseTranslationKeys.videoPromptLabel,
+              undefined,
+              translate
+            )}
             <textarea
               value={request.prompt}
               onChange={(event) =>
@@ -145,16 +178,24 @@ export function VideoGenerationEditor({
         </div>
       ) : null}
 
-      {loading && <div>Loading...</div>}
+      {loading && (
+        <div>
+          {translatePixelverseText(pixelverseTranslationKeys.videoLoading, undefined, translate)}
+        </div>
+      )}
 
       {!videoReady && selectedFile && !loading && (
-        <button onClick={handleUploadProcess}>Start Upload</button>
+        <button onClick={handleUploadProcess}>
+          {translatePixelverseText(pixelverseTranslationKeys.videoStartUpload, undefined, translate)}
+        </button>
       )}
 
       {videoReady && (
         <div>
           <video src={videoUrl} controls />
-          <button onClick={handleRegenerate}>Regenerate</button>
+          <button onClick={handleRegenerate}>
+            {translatePixelverseText(pixelverseTranslationKeys.videoRegenerate, undefined, translate)}
+          </button>
         </div>
       )}
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./agentic-foundation.js";
 export * from "./platform/index.js";
 export * from "./lib/chatWithAI.js";
+export * from "./components/pixelverse/i18n.js";
+export * from "./components/pixelverse/translations/en-GB.js";

--- a/tests/pixelverse-i18n.tests.ts
+++ b/tests/pixelverse-i18n.tests.ts
@@ -1,0 +1,111 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { VideoProviderAdapter } from "../src/platform/video-provider-adapter.js";
+import {
+  pixelverseEnGbTranslations,
+  pixelverseTranslationKeys,
+  translatePixelverseText,
+  type PixelverseTranslate,
+} from "../src/index.js";
+import VideoGenerationEditor, {
+  waitForVideoCompletion,
+} from "../src/components/pixelverse/video-generation-editor.js";
+
+const adapter: VideoProviderAdapter = {
+  uploadImage: async () => ({ imageId: 1 }),
+  generateVideo: async () => ({ videoId: 2 }),
+  getVideoResult: async () => ({ state: "completed", videoUrl: "https://example.test/video.mp4" }),
+  getBalance: async () => ({ monthlyCredit: 10, packageCredit: 20 }),
+};
+
+describe("Pixelverse translations", () => {
+  it("resolves en-GB defaults through the shared translation runtime", () => {
+    expect(
+      translatePixelverseText(pixelverseTranslationKeys.balanceMonthlyCredit, { value: 10 })
+    ).toBe("Monthly Credit: 10");
+    expect(pixelverseEnGbTranslations[pixelverseTranslationKeys.videoUploadPrompt]).toBe(
+      "Drag/Drop or Click HERE to upload"
+    );
+  });
+
+  it("falls back to package translations when a consumer translator misses a key", () => {
+    const missing: PixelverseTranslate = (key) => key;
+
+    expect(
+      translatePixelverseText(pixelverseTranslationKeys.videoPromptLabel, undefined, missing)
+    ).toBe("Prompt");
+  });
+
+  it("renders Pixelverse UI text from the package translations by default", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(VideoGenerationEditor, {
+        apiKey: "test-key",
+        adapter,
+      })
+    );
+
+    expect(markup).toContain("Loading balance...");
+    expect(markup).toContain("Drag/Drop or Click HERE to upload");
+    expect(markup).toContain('title="Upload Image"');
+    expect(markup).toContain("Prompt");
+  });
+
+  it("allows host applications to supply translated Pixelverse UI text", () => {
+    const translate: PixelverseTranslate = (key) => {
+      const translations: Partial<Record<Parameters<PixelverseTranslate>[0], string>> = {
+        [pixelverseTranslationKeys.balanceLoading]: "Balance loading",
+        [pixelverseTranslationKeys.videoPromptLabel]: "Storyboard",
+        [pixelverseTranslationKeys.videoUploadImageTitle]: "Select image",
+        [pixelverseTranslationKeys.videoUploadPrompt]: "Drop a source image",
+      };
+
+      return translations[key] ?? key;
+    };
+
+    const markup = renderToStaticMarkup(
+      React.createElement(VideoGenerationEditor, {
+        apiKey: "test-key",
+        adapter,
+        translate,
+      })
+    );
+
+    expect(markup).toContain("Balance loading");
+    expect(markup).toContain("Drop a source image");
+    expect(markup).toContain('title="Select image"');
+    expect(markup).toContain("Storyboard");
+  });
+
+  it("returns completed Pixelverse video results", async () => {
+    await expect(waitForVideoCompletion(adapter, 2, "test-key", 1, 0)).resolves.toBe(
+      "https://example.test/video.mp4"
+    );
+  });
+
+  it("resolves failed Pixelverse video errors through translations", async () => {
+    const failedAdapter: VideoProviderAdapter = {
+      ...adapter,
+      getVideoResult: async () => ({ state: "failed" }),
+    };
+    const translate: PixelverseTranslate = (key) =>
+      key === pixelverseTranslationKeys.videoErrorFailed ? "Generation failed" : key;
+
+    await expect(
+      waitForVideoCompletion(failedAdapter, 2, "test-key", 1, 0, translate)
+    ).rejects.toThrow("Generation failed");
+  });
+
+  it("resolves timed-out Pixelverse video errors through translations", async () => {
+    const pendingAdapter: VideoProviderAdapter = {
+      ...adapter,
+      getVideoResult: async () => ({ state: "pending" }),
+    };
+    const translate: PixelverseTranslate = (key) =>
+      key === pixelverseTranslationKeys.videoErrorTimeout ? "Still rendering" : key;
+
+    await expect(
+      waitForVideoCompletion(pendingAdapter, 2, "test-key", 1, 0, translate)
+    ).rejects.toThrow("Still rendering");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds package-owned Pixelverse en-GB UI translations backed by @plasius/translations.
- Wires Balance and VideoGenerationEditor display text through translation keys with a host-supplied translate override.
- Exports Pixelverse translation helpers from the package root and documents the override pattern.

Closes #14

## Validation

- npm test -- tests/pixelverse-i18n.tests.ts
- npm run typecheck
- npm run audit:eslint
- npm run test:coverage
- npm run build
- npm run audit:npm
- npm run pack:check
