### PR TITLE
chore: prepare ai 1.1.24 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/ai",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/ai",
-      "version": "1.1.23",
+      "version": "1.1.24",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/ai",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "Plasius AI functions providing chatbot, text-to-speech, speech-to-text, and AI-generated images and videos",
   "keywords": [
     "chatbot",


### PR DESCRIPTION
## Summary

- Bumps @plasius/ai package metadata to 1.1.24 so the protected-main CD workflow can publish with bump=none.
- Keeps release preparation in the PR path after CD run 26523296661 was blocked by branch protection while pushing its release commit.

Refs #14

## Validation

- npm ci --ignore-scripts
- npm test
- npm run build
